### PR TITLE
remove "fixes"

### DIFF
--- a/common/skin/dactyl.css
+++ b/common/skin/dactyl.css
@@ -152,7 +152,7 @@ label[collapsed=true] {
 statusbarpanel {
     -moz-appearance: none !important;
     border: 0 !important;
-	min-height: 18px !important;
+    min-height: 18px !important;
     background: transparent;
     text-shadow: inherit !important;
 }
@@ -222,64 +222,6 @@ statusbarpanel {
 #content-frame, #appcontent {
     border: 0px;
 }
-
-}
-
-@-moz-document url(chrome://browser/content/browser.xul) {
-
-/* Fix ginormous Australis tabs. */
-[dactyl-australis=true] :-moz-any(xul|tab.tabbrowser-tab, .tabs-newtab-button)
-        .tab-background > * {
-    min-height: 24px !important;
-    max-height: 24px !important;
-}
-
-[dactyl-australis=true] :-moz-any(xul|tab.tabbrowser-tab, .tabs-newtab-button)
-    .tab-background > :-moz-any(.tab-background-start, .tab-background-end)::after {
-    background-size: 30px 24px !important;
-    max-height: 24px !important;
-    min-height: 24px !important;
-}
-
-[dactyl-australis=true] .tabbrowser-tabs {
-    min-height: 0 !important;
-    max-height: 24px !important;
-}
-
-/* Fix stupid line... */
-[dactyl-australis=true] #navigator-toolbox::after {
-    height: 0 !important;
-}
-
-#nav-bar-customization-target > .toolbarbutton-1 {
-    margin-top: -5px !important;
-    margin-bottom: -5px !important;
-}
-
-/*
-#PanelUI-button,
-#PanelUI-menu-button,
-#nav-bar-customization-target > .toolbarbutton-1,
-#nav-bar-customization-target > .toolbarbutton-1 > xul|toolbarbutton {
-    padding: 0 !important;
-}
-
-#nav-bar-customization-target > xul|toolbaritem > .toolbarbutton-1 {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-}
-
-#nav-bar-customization-target > .toolbarbutton-1,
-#nav-bar-customization-target > .toolbarbutton-1 > xul|dropmarker > xul|image {
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-    max-height: 24px !important;
-}
-
-#nav-bar-customization-target #urlbar {
-    margin-bottom: 0 !important;
-}
-*/
 
 }
 


### PR DESCRIPTION
I spent almost an entire day hunting down what I thought were bugs. Mainly, an essential line magically disappearing and my tabs getting smaller. I don't think pentadactyl should have an opinion on how things should look. Do I think the tabs are too big? For sure I do. Do I want pentadactyl to modify them? NO. I'll install the shrink-those-bigass-tabs add-on or I'm going to write my own userChrome file if I want to do that. Pentadactyl should only display and hide stuff, not modify the way they are displayed.

I removed some comments along the way because I think they are related. Correct me if I'm wrong.
