### PR TITLE
Fixes to `highlight` and small refactoring

### DIFF
--- a/common/modules/highlight.jsm
+++ b/common/modules/highlight.jsm
@@ -166,16 +166,28 @@ var Highlights = Module("Highlight", {
         }
 
         if (newStyle == null && extend == null) {
-            if (highlight.defaultValue == null && highlight.defaultExtends.length == 0) {
-                highlight.style.enabled = false;
-                delete this.loaded[highlight.class];
-                delete this.highlight[highlight.class];
-                return null;
-            }
-            newStyle = highlight.defaultValue;
-            bases = highlight.defaultExtends;
+            return this._reset(highlight, force, bases, extend);
+        } else {
+            return this._set(highlight, newStyle, force, bases, extend);
         }
+    },
 
+    _reset: function set(highlight, force, bases, extend) {
+        if (highlight.defaultValue == null && highlight.defaultExtends.length == 0) {
+            highlight.style.enabled = false;
+            delete this.loaded[highlight.class];
+            delete this.highlight[highlight.class];
+            return null;
+        }
+        highlight.set("value", highlight.defaultValue || "");
+        highlight.extends = highlight.defaultExtends;
+        if (force)
+            highlight.style.enabled = true;
+        this.highlight[highlight.class] = highlight;
+        return highlight;
+    },
+
+    _set: function set(highlight, newStyle, force, bases, extend) {
         highlight.set("value", newStyle || "");
         highlight.extends = array.uniq(bases, true);
         if (force)
@@ -190,7 +202,7 @@ var Highlights = Module("Highlight", {
      */
     clear: function clear() {
         for (let [k, v] in Iterator(this.highlight))
-            this.set(k, null, true);
+            this._reset(v, true);
     },
 
     /**


### PR DESCRIPTION
I've tried to improve [issue 1150](https://code.google.com/p/dactyl/issues/detail?id=1150), and found some minor bugs, e.g. `:hi clear` after `:hi Foo color:red` did not clear/remove `Foo`.

https://github.com/blueyed/dactyl/commit/6c1954f21031e449c7682c5ca39aab0436cf06db was meant to improve performance, but without (much?) success.

Is there a way to profile `:hi clear`?
