### PR TITLE
Fix 'unexpected EOF' in make_jar.sh

### DIFF
--- a/common/make_jar.sh
+++ b/common/make_jar.sh
@@ -37,18 +37,17 @@ then
     }
 fi
 
-mungeliterals=$(cat <<'!'
+mungeliterals='
     local $/;
     $_ = <>;
     s{(?<!function )\bliteral\((?:function \(\) )?/\*(.*?)\*/\$?\)}{
         my $s = $1;
-        $s =~ s/[\\']/\\$&/g;
+        $s =~ s/[\\'\'']/\\$&/g;
         $s =~ s/\n/\\n\\$&/g;
-        "/* Preprocessors FTW. */ '$s'";
+        "/* Preprocessors FTW. */ '\''$s'\''";
     }ges;
     print;
-!
-)
+'
 
 mungeliterals() {
     if which perl >/dev/null 2>&1


### PR DESCRIPTION
Fix this:

    $ make -C pentadactyl xpi
    Packaging chrome...
    /.../dactyl/pentadactyl/../common/make_jar.sh: line 70: unexpected EOF while looking for matching `''
    make: *** [chrome/] Error 2
