### PR TITLE
Fix 'TypeError: options is undefined'

### DIFF
--- a/common/modules/buffer.jsm
+++ b/common/modules/buffer.jsm
@@ -1629,7 +1629,8 @@ var Buffer = Module("Buffer", {
         let timers = new WeakMap;
 
         return function smoothScrollTo(node, x, y) {
-            let { options } = overlay.activeModules;
+            let doc = node.ownerDocument || node.document || node;
+            let { options } = util.topWindow(doc.defaultView).dactyl.modules;
 
             let time = options["scrolltime"];
             let steps = options["scrollsteps"];


### PR DESCRIPTION
Fix this error that sometimes pops up after restarting the browser:

    resource://dactyl/buffer.jsm: 1634: TypeError: options is undefined