### PR TITLE
Support 'shorturl' and 'canonical' tags for yankshort

### DIFF
--- a/common/modules/buffer.jsm
+++ b/common/modules/buffer.jsm
@@ -731,9 +731,14 @@ var Buffer = Module("Buffer", {
         }
 
         let link = DOM("link[href][rev=canonical], \
+                        link[href][rel=shorturl], \
                         link[href][rel=shortlink]", doc)
                        .filter(sane)
                        .attr("href");
+
+        if (!link)
+            link = DOM("link[href][rel=canonical]", doc).filter(sane).attr("href");
+
         if (link)
             return hashify(link);
 


### PR DESCRIPTION
E.g. Amazon is providing a clean URL in rel="canonical" links.