### PR TITLE
Fix :downloads error

### DIFF
--- a/common/modules/downloads.jsm
+++ b/common/modules/downloads.jsm
@@ -231,7 +231,7 @@ var DownloadList = Class("DownloadList",
         this.nodes = {
             commandTarget: this
         };
-        this.downloads = Map();
+        this.downloads = new Map();
     },
 
     cleanup: function cleanup() {


### PR DESCRIPTION
Fix error when issuing the `:downloads` command in Firefox 42.0.