### PR TITLE
Fix pageinfo by handling _uri too.

### DIFF
--- a/common/modules/buffer.jsm
+++ b/common/modules/buffer.jsm
@@ -2929,7 +2929,11 @@ Buffer.addPageInfoSection("s", "Security", function* (verbose) {
 
         yield ["Verified by", data.caOrg];
 
-        let { host, port } = identity._lastUri;
+        let uri = identity._lastUri;
+        if (uri === undefined)
+            uri = identity._uri;
+
+        let { host, port } = uri;
         if (port == -1)
             port = 443;
 


### PR DESCRIPTION
':pageinfo s' is broken on 43.0 thanks to commit:

"Bug 1175702 - Implement mixed content states in the control center"
https://github.com/mozilla/gecko-dev/commit/4194314d45e6219696f5c93734a40f0ef5b1f247