### PR TITLE
Typo in function name "realpath".

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -176,7 +176,7 @@ xpi: $(CHROME)
 	rm -r -- $(CHROME)
 
 	@if ! which realpath >/dev/null 2>&1; \
-	then realpah() { 		\
+	then realpath() { 		\
 		local IFS="$$(echo)";	\
 		local x="$$1"; 		\
 		case "$$x" in		\


### PR DESCRIPTION
`realpah` -> `realpath`.