### PR TITLE
Fix Bookmark Tag Completion

### DIFF
--- a/common/content/bookmarks.js
+++ b/common/content/bookmarks.js
@@ -437,7 +437,7 @@ var Bookmarks = Module("bookmarks", {
             description: "A comma-separated list of tags",
             completer: function tags(context) {
                 context.generate = () => new RealSet(Array.from(bookmarkcache)
-                                                          .flatMap(b.tags));
+                                                          .flatMap(b => b.tags));
 
                 context.keys = { text: identity, description: identity };
             },


### PR DESCRIPTION
This change fixes Issue #122: Autocompleting Bookmark Tags Broken.

Correct building a set of tags from the bookmark cache by fixing the corresponding flatMap parameters.