### PR TITLE
Passthrough fix

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -817,13 +817,10 @@ var Events = Module("events", {
                     return true;
 
                 if (!this.processor && event.type === "keydown" &&
-                        options.get("passunknown").getKey(modes.main.allBases)) {
-                    if (!(modes.main.count && /^\d$/.test(key)))
-                        return true;
-
-                    if (modes.main.allBases.some(hasCandidates))
-                        return true;
-                }
+                        options.get("passunknown").getKey(modes.main.allBases) &&
+                        !(modes.main.count && /^\d$/.test(key) ||
+                        modes.main.allBases.some(hasCandidates)))
+                    return true;
 
                 return false;
             })();

--- a/common/content/mappings.js
+++ b/common/content/mappings.js
@@ -245,7 +245,7 @@ var MapHive = Class("MapHive", Contexts.Hive, {
     get: function (mode, cmd, skipPassThrough = false) {
         let map = this.getStack(mode).mappings[cmd];
 
-        if (skipPassThrough && map && !map.passThrough)
+        if (skipPassThrough && map && map.passThrough)
             return null;
         return map;
     },


### PR DESCRIPTION
I was having passthrough issues like issues #118, #119, and #121. I bisected commits backed and narrowed the problem down to 28fe4af, where keyup's pass assignment was converted to a function. I found two issues:
* The final passthrough test in the pass assignment previously had both the digit test and the mapping test connected: both had to be false in order to return true. The updated code had disconnected them, which I'm guessing was because of the trickiness of the parentheses. I tried to correct this following the established code styles.
* The get method in mapHive would return null is skipPassthrough was true and the mapping's passthrough property was false. I'm pretty sure the map.passthrough should have been true instead.

Although I haven't done any Firefox plugin development before and I didn't quite following the abstraction changes in Pentadactyl, I'm fairly confident that the logic changes I've made are correct. I've A/Bed against previous successful commits and util.dumped a lot of vars to make sure things seem right.