### PR TITLE
Fix 'split' method when using String not RegExp

### DIFF
--- a/common/modules/util.jsm
+++ b/common/modules/util.jsm
@@ -1580,9 +1580,9 @@ var Util = Module("Util", XPCOM([Ci.nsIObserver, Ci.nsISupportsWeakReference]), 
      * @returns {[string]}
      */
     split: function split(str, re, limit) {
-        re.lastIndex = 0;
         if (!re.global)
             re = RegExp(re.source || re, "g");
+        re.lastIndex = 0;
         let match, start = 0, res = [];
         while (--limit && (match = re.exec(str)) && match[0].length) {
             res.push(str.substring(start, match.index));


### PR DESCRIPTION
If regular expression for splitting is provided as String
instead of RegExp, it breaks split method since String
doesn't have desired properties.

Fixes #138