### PR TITLE
Offset the index by 1 so matches show from 1 to n

### DIFF
--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1600,7 +1600,7 @@ var CommandLine = Module("commandline", {
                 statusline.progress = "";
             else
                 statusline.progress = _("completion.matchIndex",
-                                        this.itemList.getOffset(idx),
+                                        this.itemList.getOffset(idx) + 1,
                                         this.itemList.itemCount);
         },
 


### PR DESCRIPTION
Matches on the statusline used to show from "match 0 of 10" to "match 9 of 10", so this makes them show from "match 1 of 10" to "match 10 of 10" instead.