### PR TITLE
Account for When the Default Profile Name has Numbers

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -103,7 +103,8 @@ install:
 		awk -v "profile=$(PROFILE)"					\
 			'BEGIN { RS="#" } 					\
 			index($$0, "\nName=" profile "\n") { print; exit } 	\
-			!profile && /\nName=default\n/ { args["name=default"] = $$0 } 	\
+			!profile && /\nName=default([\-0-9]*)?\n/  		\
+			    { args["name=default"] = $$0 } 			\
 			!profile && /\nDefault=1/ { args["default=1"] = $$0 } 	\
 			END {							\
 				if (args["default=1"]) print args["default=1"];	\


### PR DESCRIPTION
Sometimes the default profile name in the `profiles.ini` file for Firefox has numbers in it.

The default configuration on my computer was: 
```
[General]
StartWithLastProfile=1

[Profile0]
Name=default-1461165984967
IsRelative=1
Path=Profiles/15xzltqw.default-1461165984967
```

I just changed the RegEx from `/\nName=default\n/` to `/\nName=default([\-0-9]*)?\n/` in order to match a number if one exists. 

This fix will not break matching for when the config is just: 
```
[General]
StartWithLastProfile=1

[Profile0]
Name=default
IsRelative=1
Path=Profiles/15xzltqw.default-1461165984967
```