### PR TITLE
Fix `No such autocomplete provider: 'history'`

### DIFF
--- a/pentadactyl/content/config.js
+++ b/pentadactyl/content/config.js
@@ -203,7 +203,7 @@ var Config = Module("config", ConfigBase, {
         const { document } = window;
 
         completion.location = function location(context) {
-            completion.autocomplete("history", context);
+            completion.autocomplete("unifiedcomplete", context);
             context.title = ["Smart Completions"];
         };
 


### PR DESCRIPTION
In Firefox 49, the 'history' component was removed, so that uses
'unifiedcomplete' here instead.

More to see: https://bugzil.la/1223728