### PR TITLE
Fix `TypeError: options is undefined`

### DIFF
--- a/common/content/dactyl.js
+++ b/common/content/dactyl.js
@@ -2071,8 +2071,20 @@ var Dactyl = Module("dactyl", XPCOM(Ci.nsISupportsWeakReference, ModuleBase), {
         dactyl.initialized = true;
 
         util.delay(() => {
-            if (services.focus.activeWindow === window)
+            if (services.focus.activeWindow === window) {
                 overlay.activeWindow = window;
+            } else {
+                const onActivate = evt => {
+                    if (evt.target === window) {
+                        overlay.activeWindow = window;
+                    }
+                }
+                window.addEventListener("activate", onActivate, true);
+                window.addEventListener("unload", function onUnload() {
+                    window.removeEventListener("unload", onUnload);
+                    window.removeEventListener("activate", onActivate, true);
+                });
+            }
 
             util.flushLateMethods(dactyl);
         });

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -618,9 +618,6 @@ var Events = Module("events", {
                 util.trapErrors("addEditActionListener",
                                 DOM(elem).editor, editor);
 
-            if (elem == window)
-                overlay.activeWindow = window;
-
             overlay.setData(elem, "had-focus", true);
             if (event.target instanceof Ci.nsIDOMXULTextBoxElement)
                 if (Events.isHidden(elem, true))


### PR DESCRIPTION
When open a new window and close it, then press `gg` in the original window
will throw `TypeError: options is undefined`.