### PR TITLE
Bump Max Version to 49

### DIFF
--- a/pentadactyl/install.rdf
+++ b/pentadactyl/install.rdf
@@ -32,7 +32,7 @@
             <Description
                 em:id="{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
                 em:minVersion="38.0"
-                em:maxVersion="48.*"/>
+                em:maxVersion="49.*"/>
         </em:targetApplication>
     </Description>
 </RDF>


### PR DESCRIPTION
Update  `install.rdf` to support installations on Firefox version 49.