### PR TITLE
Explicitly disable multiprocess Firefox

### DIFF
--- a/pentadactyl/install.rdf
+++ b/pentadactyl/install.rdf
@@ -9,6 +9,7 @@
         em:description="Firefox for Vim and Links addicts"
         em:homepageURL="http://5digits.org/pentadactyl"
         em:bootstrap="true"
+        em:multiprocessCompatible="false"
         em:strictCompatibility="true">
 
         <em:creator>Kris Maglione, Doug Kearns</em:creator>


### PR DESCRIPTION
Starting with Firefox 51, e10s will turned on for users without addons that explicitly state that they are not compatible (like Pentadactyl). See the Firefox 51 entry at https://wiki.mozilla.org/Add-ons/2017