### PR TITLE
Fix invalid 'in' operand in values()

### DIFF
--- a/common/modules/base.jsm
+++ b/common/modules/base.jsm
@@ -443,7 +443,7 @@ function values(obj) {
     if (isinstance(obj, ["Generator", "Iterator", Iter]))
         return iter(obj);
 
-    if (Symbol.iterator in obj)
+    if (typeof obj === 'object' && Symbol.iterator in obj)
         return iter(obj[Symbol.iterator]());
 
     return iter(function* () {


### PR DESCRIPTION
invalid 'in' operand obj  base.jsm:446
        values resource://dactyl/base.jsm:446:1
        BookmarkCache<["@@iterator"]
resource://dactyl/bookmarkcache.jsm:97:16
        BookmarkCache<.keywords<
resource://dactyl/bookmarkcache.jsm:104:1
        g_Memoize resource://dactyl/base.jsm:1051:64
        search resource://dactyl-content/bookmarks.js:700:17
        completer resource://dactyl-content/bookmarks.js:665:21
        forkapply resource://dactyl/completion.jsm:820:23
        fork resource://dactyl/completion.jsm:807:16
        completions resource://dactyl/options.jsm:819:20
        validateCompleter resource://dactyl/options.jsm:834:26
        validator resource://dactyl/options.jsm:418:20
        isValidValue resource://dactyl/options.jsm:241:16
        op resource://dactyl/options.jsm:272:18
        setAction resource://dactyl/options.jsm:1324:35
        initCommands/</< resource://dactyl/options.jsm:1517:21
        exec resource://dactyl/commands.jsm:193:17
        trapErrors resource://dactyl-content/dactyl.js:1159:20
        execute resource://dactyl/commands.jsm:182:17
        execute resource://dactyl-content/dactyl.js:555:26
        execute/</< resource://dactyl/commands.jsm:812:33
        withSavedValues resource://dactyl/base.jsm:1103:20
        execute/< resource://dactyl/commands.jsm:779:21
        withContext/< resource://dactyl/contexts.jsm:612:20
        withSavedValues resource://dactyl/base.jsm:1103:20
        withContext resource://dactyl/contexts.jsm:610:16
        execute resource://dactyl/commands.jsm:777:17
        Local/source/< resource://dactyl/io.jsm:191:29
        withContext/< resource://dactyl/contexts.jsm:612:20
        withSavedValues resource://dactyl/base.jsm:1103:20
        withContext resource://dactyl/contexts.jsm:610:16
        source resource://dactyl/io.jsm:137:24
        initLoad/< resource://dactyl-content/dactyl.js:2025:29
        timeout/timeout_notify resource://dactyl/base.jsm:1134:17