### PR TITLE
Change regex to match all possible function string representations

### DIFF
--- a/common/modules/base.jsm
+++ b/common/modules/base.jsm
@@ -923,7 +923,7 @@ function Class(...args) {
         })',
         "constructor", (name || superclass.className).replace(/\W/g, "_"))
             .replace("PARAMS",
-                     /^function .*?\((.*?)\)/
+                     /^.*?\((.*?)\)/
                         .exec(args[0] && args[0].init || Class.prototype.init)[1]
                         .replace(/\b(self|res|Constructor)\b/g, "$1_")));
 


### PR DESCRIPTION
In Firefox 54, it is possible for a function defined inside of an object like `{foo(arg) {alert(arg)}}` to have string representation `foo(arg) {alert(arg)}` instead of `function foo(arg) {alert(arg)}`. This was the case for the `init` method of `Iter` on line 1832 of common/base.jsm.

This fixes #209 for me. I'm not 100% sure that there aren't other side effects. With this Pentadactyl loads and the command line works. You can use `:open` to open URL's. However, other features seem to be broken like hints.